### PR TITLE
better aproach to read source file, introduce xfree macro and some error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
-all:
-	gcc main.c
-	./a.out
+CC ?= cc
+CFLAGS := -std=gnu99 -Wall -Wextra -pedantic -Og -ggdb
+
+BIN := a.out
+
+$(BIN): main.c
+	$(CC) $(CFLAGS) main.c

--- a/main.c
+++ b/main.c
@@ -1,9 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
-#define MAX_FILE_SZ (8192)
-#define BUFF_SZ (128)
+/**
+ * free() ignores NULL pointer by default. set each pointer to NULL
+ * after calling free() to avoid double free error.
+ */
+#define xfree(p) do { free((p)); (p) = NULL; } while (0)
 
 typedef struct typed_struct_
 {
@@ -11,6 +15,8 @@ typedef struct typed_struct_
     void *data;
     struct typed_struct_ *next;
 } typed_struct;
+
+char *read_source_file(FILE *fp);
 
 typed_struct *next_token(char **inp_ptr)
 {
@@ -46,24 +52,31 @@ typed_struct *next_token(char **inp_ptr)
 typed_struct *tokenize(char *inp)
 {
     char **ptr = &inp;
-    typed_struct *a = next_token(ptr);
-    printf("%s", (char *)a->data);
-    typed_struct *b = next_token(ptr);
-    printf("%s", (char *)b->data);
-    typed_struct *c = next_token(ptr);
-    printf("%s", (char *)c->data);
+    typed_struct *t = next_token(ptr);
+    while (t) {
+        printf("%s\n", (char*)t->data);
+        t = next_token(ptr);
+    }
     return NULL;
 }
 
 int main(void)
 {
-    FILE *fptr = fopen("inp.c", "r");
-    char *content = malloc(sizeof(char) * MAX_FILE_SZ);
-    char buff[BUFF_SZ];
-    content[0] = 0;
-    while (fgets(buff, 100, fptr))
-    {
-        strcat(content, buff);
+    int ret = 0;
+    char *content = NULL;
+
+    FILE *fp = fopen("./inp.c", "rb");
+    if (!fp) {
+        perror("failed to read source file");
+        ret = 1;
+        goto defer_exit;
+    }
+
+    content = read_source_file(fp);
+    if (!content) {
+        fprintf(stderr, "failed to read source file: read_source_file returned NULL\n");
+        ret = 1;
+        goto defer_exit;
     }
 
     typed_struct *tkn = tokenize(content);
@@ -72,5 +85,27 @@ int main(void)
         tkn = tkn->next;
     }
 
-    free(content);
+defer_exit:
+    if (fp)
+        fclose(fp);
+    if (content)
+        xfree(content);
+    return ret;
+}
+
+char *read_source_file(FILE *fp) {
+    char *data = NULL;
+    struct stat st;
+
+    if (fstat(fileno(fp), &st) == -1)
+        goto ret;
+
+    data = calloc(st.st_size, sizeof(char));
+    if (!data)
+        goto ret;
+
+    fread(data, sizeof(char), st.st_size, fp);
+
+ret:
+    return data;
 }


### PR DESCRIPTION
Wrote seperate function to read source files named `read_source_file(FILE *fp)`. checked for NULL pointers, closed open files and print all tokens after tokenization phase.
Also introduced `xfree(p)` macro to avoid double free memory error.

Changed Makefile to add `CFLAGS` to include useful debug information and enabled all compiler warnings.