### PR TITLE
allow top-level comments

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -496,7 +496,9 @@ typed_token *next_token(char **inp_ptr)
 typed_token *tokenize(char *inp)
 {
     char **ptr = &inp;
-    typed_token *t = next_token(ptr);
+    typed_token *t;
+    while ((t = next_token(ptr))->type_id == TKN_COMMENT) {}
+
     typed_token *first = t;
 
     while (t)


### PR DESCRIPTION
previously, having a top-level comment like this lead to parsing failure:

```c
// salam

int main() {
    return 0;
}
```